### PR TITLE
chore: add Context7 MCP server configuration [no-ci]

### DIFF
--- a/.github/workflows/context7.yml
+++ b/.github/workflows/context7.yml
@@ -1,0 +1,17 @@
+name: Update Context7 Documentation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Context7 Documentation
+        id: context7
+        uses: rennf93/upsert-context7@1.1
+        with:
+          operation: refresh

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/deepgram-starters/flask-transcription",
+  "public_key": "pk_hu7APZeIXQ14hNyaCBm0A"
+}


### PR DESCRIPTION
Adds Context7 configuration file to enable documentation lookups.

This is a non-release change (marked [no-ci] to prevent release-please from triggering).