### PR TITLE
chore: upgrade to deepgram-sdk v7

### DIFF
--- a/deepgram.toml
+++ b/deepgram.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/deepgram-starters/flask-transcription"
 useCase = "transcription"
 language = "python"
 framework = "flask"
-sdk = "6.0.0-rc.1"
+sdk = "deepgram-sdk"
 tags = ["transcription", "stt", "speech-to-text", "asr", "pre-recorded", "python", "flask"]
 
 # Check prerequisites

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deepgram-sdk==6.0.0
+deepgram-sdk>=7.6.0
 flask==3.1.0
 flask-cors==5.0.0
 PyJWT==2.10.1


### PR DESCRIPTION
## What
Upgrade this starter from `deepgram-sdk` v6 to v7 (floor `>=7.6.0`) to standardize on the current major version.

## How
- `requirements.txt`: `deepgram-sdk==6.0.0` -> `deepgram-sdk>=7.6.0`.
- `deepgram.toml`: `sdk` metadata `6.0.0-rc.1` -> `deepgram-sdk`.
- No application code changes required: the app uses only `from deepgram import DeepgramClient` and REST methods, whose signatures are unchanged between v6 and v7 (per the official v6->v7 migration guide). No renamed/removed generated types are imported.
- Runtime already satisfies v7's Python >=3.10 requirement (`deploy/Dockerfile` uses `python:3.13-slim`).

## Verified
- Built a Python 3.12 venv, `pip install -r requirements.txt` (resolved `deepgram-sdk 7.6.0`), and imported the app cleanly (`python -c "import app"`).

## Manual verification needed
- [ ] Run the app end to end against a real Deepgram API key and confirm the primary request round-trip still succeeds.
- [ ] Confirm the frontend renders the response unchanged.
